### PR TITLE
fix(component): handle falsy conditionals

### DIFF
--- a/lib/forms/utils.ts
+++ b/lib/forms/utils.ts
@@ -88,7 +88,7 @@ const applyConditionsReducer =
                 if (
                     filter(propUi['ui:if'], (predicate, k) => {
                         const value = get(data, k);
-                        return predicate && predicate !== value;
+                        return predicate !== value;
                     }).length === 0
                 ) {
                     Object.assign(acc, curr);


### PR DESCRIPTION
Allows using `false` for `ui:if` (e.g. show field if checkbox is unchecked)