### PR TITLE
fix(component): initialize with correct data

### DIFF
--- a/lib/forms/component.tsx
+++ b/lib/forms/component.tsx
@@ -117,7 +117,7 @@ export function configure<MutationNamesType = {}>(opts: ApolloFormConfigureOptio
                 schemaWithConditionals: applyConditionsToSchema(
                     schema,
                     this.props.ui,
-                    this.state.data
+                    this.props.data
                 )
             }));
         }


### PR DESCRIPTION
use props instead of state on mount, to properly initialize conditional fields

https://github.com/wittydeveloper/react-apollo-form/pull/39#issuecomment-494423942